### PR TITLE
Edge Clipboard, alert div to class

### DIFF
--- a/summernote-cleaner.js
+++ b/summernote-cleaner.js
@@ -73,12 +73,19 @@
                 'summernote.paste':function(we,e){
                     if(options.action=='both'||options.action=='paste'){
                         e.preventDefault();
-                        var text=e.originalEvent.clipboardData.getData('text/plain');
+                        var ua = window.navigator.userAgent;
+                        var msie = ua.indexOf("MSIE ");
+                        if (msie > 0 || !!navigator.userAgent.match(/Trident.*rv\:11\./))  { // If Internet Explorer, return version number
+                            var text=window.clipboardData.getData("Text");
+                            
+                        } else { // If another browser, return 0
+                            var text=e.originalEvent.clipboardData.getData('text/plain');
+                        }
                         var text=cleanText(text);
                         var $dom=$('<div class="pasted"/>').html(text);
                         $note.summernote('insertNode',$dom[0]);
-                        $('.note-resizebar').append('<div id="cleanerAlert" style="position:absolute;bottom:0;left:2px;font-size:10px;">'+lang.cleaner.notification+'</div>');
-                        setTimeout(function(){$('#cleanerAlert').remove();},options.time);
+                        $('.note-resizebar').append('<div class="cleanerAlert" style="position:absolute;bottom:0;left:2px;font-size:10px;">'+lang.cleaner.notification+'</div>');
+                        setTimeout(function(){$('.cleanerAlert').remove();},options.time);
                     }
                 }
             }


### PR DESCRIPTION
I ran into a pasting issue for Microsoft Edge which probably affects other versions of Internet Explorer. Because of a security setting, IE may block access to the clipboard http://www.thewindowsclub.com/harden-clipboard-data-theft-ie. There is certainly a cleaner way to write it but the code.
Also for reference: https://msdn.microsoft.com/en-us/library/ms535220(v=vs.85).aspx

I fixed and corrected the both || paste version but not the button and tested it in Edge and Google Chrome.  Both browsers behaved as expected.

There was also an issue when there are two (or more) summernote divs with separate ids. After a paste event, the cleanerAlert div is added to all summernote divs.  When the timeout event happens, only the first cleanerAlert div is removed.  By switching to class, the timer removes it from both.  It would be great to have you rewrite so that the cleanerAlert div is applied and subsequently removed for the summernote div with the paste event.

Thanks for reviewing and I apologize for writing this initially in a comment.  Thanks for teaching.
