### PR TITLE
Trailing comma

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,5 +23,5 @@
         "type": "git",
         "url": "git://github.com/StudioJunkyard/summernote-cleaner.git"
     },
-    "homepage": "https://github.com/StudioJunkyard/summernote-cleaner",
+    "homepage": "https://github.com/StudioJunkyard/summernote-cleaner"
 }


### PR DESCRIPTION
Static JSON files don't tolerate trailing commas in the same way that dynamic js does...

I feel a bit silly for not spotting this earlier...