### PR TITLE
fix: in case non-html content was pasted, don’t clean anything

### DIFF
--- a/summernote-cleaner.js
+++ b/summernote-cleaner.js
@@ -104,7 +104,6 @@
       this.events={
         'summernote.paste':function(we,e){
           if(options.cleaner.action=='both'||options.cleaner.action=='paste'){
-            e.preventDefault();
             var ua=window.navigator.userAgent;
             var msie=ua.indexOf("MSIE ");
             msie=msie>0||!!navigator.userAgent.match(/Trident.*rv\:11\./);
@@ -113,18 +112,22 @@
             }else{
               var text=e.originalEvent.clipboardData.getData((options.cleaner.keepHtml?'text/html':'text/plain'));
             }
-            var text=cleanText(text,options.cleaner.newline);
-            var pasteFn=function(){
-              $note.summernote('pasteHTML',text);
-            }
-            if(msie){
-              setTimeout(pasteFn,1);
-            }else{
-              pasteFn();
-            }
-            if(options.cleaner.notTime>0){
-              $editor.find('.note-resizebar').append('<div class="summernote-cleanerAlert alert alert-success" style="'+options.cleaner.notStyle+'">'+lang.cleaner.not+'</div>');
-              setTimeout(function(){$editor.find('.summernote-cleanerAlert').remove();},options.cleaner.notTime);
+  
+            if (text && text != '') {
+              e.preventDefault();
+              var text=cleanText(text,options.cleaner.newline);
+              var pasteFn=function(){
+                $note.summernote('pasteHTML',text);
+              }
+              if(msie){
+                setTimeout(pasteFn,1);
+              }else{
+                pasteFn();
+              }
+              if(options.cleaner.notTime>0){
+                $editor.find('.note-resizebar').append('<div class="summernote-cleanerAlert alert alert-success" style="'+options.cleaner.notStyle+'">'+lang.cleaner.not+'</div>');
+                setTimeout(function(){$editor.find('.summernote-cleanerAlert').remove();},options.cleaner.notTime);
+              }
             }
           }
         }


### PR DESCRIPTION
Tested in chrome, pasting plain text in a summernote editor, rigged with the cleaner plugin, results in the folowing exception:

    Uncaught TypeError: Failed to execute 'setStart' on 'Range': parameter 1 is not of type 'Node'.
    at g (vendor.1f0b3ecb.js:31)
    at c.select (vendor.1f0b3ecb.js:31)
    at Editor.<anonymous> (vendor.1f0b3ecb.js:32)
    at Editor.pasteHTML (vendor.1f0b3ecb.js:32)
    at Context.invoke (vendor.1f0b3ecb.js:31)
    at _.fn.init.summernote (vendor.1f0b3ecb.js:31)
    at HTMLDivElement.summernote.paste (vendor.1f0b3ecb.js:40)
    at HTMLDivElement.dispatch (vendor.1f0b3ecb.js:2)
    at HTMLDivElement.q.handle (vendor.1f0b3ecb.js:2)
    at Object.trigger (vendor.1f0b3ecb.js:2)

Getting the clipboard data from the event as `text/html` content type returns an empty text. It goes haywire when passing this empty string to summernote using the `pasteHTML` command.

My pull request checks if the text to clean is empty. if so, no cleaning is done and the event is *not* prevented, letting summernote handle it, pasting the plain text just like nothing happened ;)