### PR TITLE
Fixes TypeError when pasting content with keepHtml and keepClasses options set to true

### DIFF
--- a/summernote-cleaner.js
+++ b/summernote-cleaner.js
@@ -40,9 +40,10 @@
       var lang=options.langInfo;
       var cleanText=function(txt,nlO){
         if(options.cleaner.keepHtml){
+          var out = txt;
           if(!options.cleaner.keepClasses){
             var sS=/(\n|\r| class=(")?Mso[a-zA-Z]+(")?)/g;
-            var out=txt.replace(sS,' ');
+            out=txt.replace(sS,' ');
           }
           var nL=/(\n)+/g;
           out=out.replace(nL,nlO);


### PR DESCRIPTION
Tested in chrome, fixes an issue where chrome throws typerror if **keepHtml** and **keepClasses** options are set to true due to undefined variable `out`.

```
Uncaught TypeError: Cannot read property 'replace' of undefined
    at cleanText (summernote-cleaner.js:49)
    at HTMLDivElement.summernote.paste (summernote-cleaner.js:123)
    at HTMLDivElement.dispatch (jquery.js:5206)
    at HTMLDivElement.elemData.handle (jquery.js:5014)
    at Object.trigger (jquery.js:8201)
    at HTMLDivElement.<anonymous> (jquery.js:8269)
    at Function.each (jquery.js:362)
    at jQuery.fn.init.each (jquery.js:157)
    at jQuery.fn.init.trigger (jquery.js:8268)
    at Context.triggerEvent (summernote.js:1707)
```