### PR TITLE
Fix Tooltip

### DIFF
--- a/summernote-cleaner.js
+++ b/summernote-cleaner.js
@@ -84,6 +84,7 @@
           var button = ui.button({
             contents: options.cleaner.icon,
             tooltip: lang.cleaner.tooltip,
+            container: 'body',
             click:function () {
               if ($note.summernote('createRange').toString())
                 $note.summernote('pasteHTML', $note.summernote('createRange').toString());


### PR DESCRIPTION
Tooltip have conflict with jQuery as it does not know in which container to render the tooltip. Set ‘body’ as container for tooltip.

Resolve #54 