### PR TITLE
Allow keeping tables from Word

### DIFF
--- a/summernote-cleaner.js
+++ b/summernote-cleaner.js
@@ -76,10 +76,8 @@
             var aS = new RegExp(' ' + bA[ii] + '=[\'|"](.*?)[\'|"]', 'gi');
                out = out.replace(aS, '');
             
-               aS = new RegExp(" " + bA[ii] + "=(.*?) ", "gi");
-               out = out.replace(aS, " ");
-               aS = new RegExp(" " + bA[ii] + "=(.*?)>", "gi");
-               out = out.replace(aS, ">");
+               aS = new RegExp(" " + bA[ii] + "[=0-9a-z]", "gi");
+               out = out.replace(aS, "");
           }
         }
 

--- a/summernote-cleaner.js
+++ b/summernote-cleaner.js
@@ -75,8 +75,16 @@
             //var aS=new RegExp(' ('+bA[ii]+'="(.*?)")|('+bA[ii]+'=\'(.*?)\')', 'gi');
             var aS = new RegExp(' ' + bA[ii] + '=[\'|"](.*?)[\'|"]', 'gi');
                out = out.replace(aS, '');
+            
+               aS = new RegExp(" " + bA[ii] + "=(.*?) ", "gi");
+               out = out.replace(aS, " ");
+               aS = new RegExp(" " + bA[ii] + "=(.*?)>", "gi");
+               out = out.replace(aS, ">");
           }
         }
+
+        var sS = new RegExp("[ ]{1,}>", "gi");
+        out = out.replace(sS, ">");
         return out;
       };
       if (options.cleaner.action == 'both' || options.cleaner.action == 'button') {
@@ -158,9 +166,9 @@
                 msie = msie > 0 || !!navigator.userAgent.match(/Trident.*rv\:11\./);
             var ffox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
             if (msie)
-              var text = window.clipboardData.getData("Text");
+              var text = window.clipboardData.getData("text/html");
             else
-              var text = e.originalEvent.clipboardData.getData(options.cleaner.keepHtml ? 'Text' : 'text/plain');
+              var text = e.originalEvent.clipboardData.getData(options.cleaner.keepHtml ? 'text/html' : 'text/plain');
             if (text) {
               if (msie || ffox)
                 setTimeout(function(){$note.summernote('pasteHTML', cleanText(text, options.cleaner.newline));}, 1);

--- a/summernote-cleaner.js
+++ b/summernote-cleaner.js
@@ -166,7 +166,7 @@
                 msie = msie > 0 || !!navigator.userAgent.match(/Trident.*rv\:11\./);
             var ffox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
             if (msie)
-              var text = window.clipboardData.getData("text/html");
+              var text = window.clipboardData.getData("Text");
             else
               var text = e.originalEvent.clipboardData.getData(options.cleaner.keepHtml ? 'text/html' : 'text/plain');
             if (text) {

--- a/summernote-cleaner.js
+++ b/summernote-cleaner.js
@@ -76,13 +76,11 @@
             var aS = new RegExp(' ' + bA[ii] + '=[\'|"](.*?)[\'|"]', 'gi');
                out = out.replace(aS, '');
             
-               aS = new RegExp(" " + bA[ii] + "[=0-9a-z]", "gi");
-               out = out.replace(aS, "");
+               aS = new RegExp(' ' + bA[ii] + '[=0-9a-z]', 'gi');
+               out = out.replace(aS, '');
           }
         }
 
-        var sS = new RegExp("[ ]{1,}>", "gi");
-        out = out.replace(sS, ">");
         return out;
       };
       if (options.cleaner.action == 'both' || options.cleaner.action == 'button') {


### PR DESCRIPTION
When pasting tables, the `e.originalEvent.clipboardData.getData("Text")` remove all the `<table>` tags. Using text/html forces the 'raw' input of the string.

This:
```
aS = new RegExp(" " + bA[ii] + "[=0-9a-z]", "gi");
out = out.replace(aS, "");
```
Ensure tags like <table cellpadding=1> to also be removed (we cannot use the "" to ensure it won't find too much, but forcing it to 0-9a-z should be enough to capture them).