### PR TITLE
Update matching regex for attributes without quotes

### DIFF
--- a/summernote-cleaner.js
+++ b/summernote-cleaner.js
@@ -76,7 +76,7 @@
             var aS = new RegExp(' ' + bA[ii] + '=[\'|"](.*?)[\'|"]', 'gi');
                out = out.replace(aS, '');
             
-               aS = new RegExp(' ' + bA[ii] + '[=0-9a-z]', 'gi');
+               aS = new RegExp(' ' + bA[ii] + '=[0-9a-z]{1,}', 'gi');
                out = out.replace(aS, '');
           }
         }


### PR DESCRIPTION
Hi! When implementing this for a project, I noticed a minor issue where the regex (https://github.com/DiemenDesign/summernote-cleaner/pull/70) would match the wrong values. As a result removing border from this `<table border=1 cellspacing=5>` would result in: `<table cellspacing=15>`. The new Regex fixes this.

Sorry and thanks!