### PR TITLE
bug\Resolved odd desynch between code view and editor view when pasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# summernote-cleaner v1.0.6
+# summernote-cleaner v1.0.7
 A plugin for the [Summernote](https://github.com/summernote/summernote/) WYSIWYG editor.
 
 summernote-cleaner removes the unnecessary and possibly layout breaking Crud that gets added by MSWord, Open Office, and Libre Office Documents.
@@ -39,17 +39,17 @@ $('.summernote').summernote({
         ['help',['help']]
     ],
     cleaner: {
-          action: 'both',
-          icon: '<i class="note-icon">[Your Button]</i>',
-          keepHtml: true,
-          keepTagContents: ['span'], //Remove tags and keep the contents
-          badTags: ['applet', 'col', 'colgroup', 'embed', 'noframes', 'noscript', 'script', 'style', 'title', 'meta', 'link', 'head'], //Remove full tags with contents
-          badAttributes: ['bgcolor', 'border', 'height', 'cellpadding', 'cellspacing', 'lang', 'start', 'style', 'valign', 'width'],
-          limitChars: false,
-          limitDisplay: 'both',
-          limitStop: false,
-          notTimeOut: 850, //time before status message is hidden in miliseconds
-          imagePlaceholder: 'https://via.placeholder.com/200' // URL, or relative path to file.
+      action: 'both', // both|button|paste 'button' only cleans via toolbar button, 'paste' only clean when pasting content, both does both options.
+      icon: '<i class="note-icon"><svg xmlns="http://www.w3.org/2000/svg" id="libre-paintbrush" viewBox="0 0 14 14" width="14" height="14"><path d="m 11.821425,1 q 0.46875,0 0.82031,0.311384 0.35157,0.311384 0.35157,0.780134 0,0.421875 -0.30134,1.01116 -2.22322,4.212054 -3.11384,5.035715 -0.64956,0.609375 -1.45982,0.609375 -0.84375,0 -1.44978,-0.61942 -0.60603,-0.61942 -0.60603,-1.469866 0,-0.857143 0.61608,-1.419643 l 4.27232,-3.877232 Q 11.345985,1 11.821425,1 z m -6.08705,6.924107 q 0.26116,0.508928 0.71317,0.870536 0.45201,0.361607 1.00781,0.508928 l 0.007,0.475447 q 0.0268,1.426339 -0.86719,2.32366 Q 5.700895,13 4.261155,13 q -0.82366,0 -1.45982,-0.311384 -0.63616,-0.311384 -1.0212,-0.853795 -0.38505,-0.54241 -0.57924,-1.225446 -0.1942,-0.683036 -0.1942,-1.473214 0.0469,0.03348 0.27455,0.200893 0.22768,0.16741 0.41518,0.29799 0.1875,0.130581 0.39509,0.24442 0.20759,0.113839 0.30804,0.113839 0.27455,0 0.3683,-0.247767 0.16741,-0.441965 0.38505,-0.753349 0.21763,-0.311383 0.4654,-0.508928 0.24776,-0.197545 0.58928,-0.31808 0.34152,-0.120536 0.68974,-0.170759 0.34821,-0.05022 0.83705,-0.07031 z"/></svg></i>',
+      keepHtml: true,
+      keepTagContents: ['span'], //Remove tags and keep the contents
+      badTags: ['applet', 'col', 'colgroup', 'embed', 'noframes', 'noscript', 'script', 'style', 'title', 'meta', 'link', 'head'], //Remove full tags with contents
+      badAttributes: ['bgcolor', 'border', 'height', 'cellpadding', 'cellspacing', 'lang', 'start', 'style', 'valign', 'width', 'data-(.*?)'], //Remove attributes from remaining tags
+      limitChars: 0, // 0|# 0 disables option
+      limitDisplay: 'both', // none|text|html|both
+      limitStop: false, // true/false
+      notTimeOut: 850, //time before status message is hidden in miliseconds
+      imagePlaceholder: 'https://via.placeholder.com/200'
     }
 });
 ```
@@ -66,8 +66,12 @@ Options: ( both | button | paste )
 - true = Keeps HTML Markup and put through parser to remove Word Crud.
 - false = Removes tag elements using the text version of the pasted content from the clipboard.
 
+**keepTagContents**
+Removes the tag but keeps the contents, e.g. useful for removing links or spans without losing text content
+
 **badTags:**
 Remove full tags with contents. Tags listed by name only ['style',  'script']`
+NB: any tag not present in keepTagContents or badTags will remain
 
 **badAttributes:**
 Remove attributes from tags. Attributes listed by name only `['style',  'start']`
@@ -101,6 +105,9 @@ Replace pasted images with a nominated placeholder.
   - Check out our other Summernote Plugins via our main Github page.
 
 # CHANGELOG:
+#### v1.0.7
+- Resolved issue in some cases where code view would be out of synch with editor
+
 #### v1.0.6
 - Added cleanup of data- attributes
 

--- a/summernote-cleaner.js
+++ b/summernote-cleaner.js
@@ -1,5 +1,5 @@
 /* https://github.com/DiemenDesign/summernote-cleaner */
-/* Version: 1.0.6 */
+/* Version: 1.0.7 */
 (function(factory) {
   if (typeof define === 'function' && define.amd) {
     define(['jquery'], factory);
@@ -141,12 +141,16 @@
               text = event.originalEvent.clipboardData.getData(dataType);
             }
             if (text) {
+              /*clean the text first to prevent issues where code view wasn't updating correctly*/
+              var cleanedContent = cleanPaste(text, options.cleaner.badTags, options.cleaner.keepTagContents, options.cleaner.badAttributes, options.cleaner.imagePlaceholder, isHtmlData);
               if (msie || ffox) {
                 setTimeout(function () {
-                  $note.summernote('pasteHTML', cleanPaste(text, options.cleaner.badTags, options.cleaner.keepTagContents, options.cleaner.badAttributes, options.cleaner.imagePlaceholder, isHtmlData));
+                  $note.summernote('pasteHTML', cleanedContent);
                 }, 1);
-              } else
-                $note.summernote('pasteHTML', cleanPaste(text, options.cleaner.badTags, options.cleaner.keepTagContents, options.cleaner.badAttributes, options.cleaner.imagePlaceholder, isHtmlData));
+              } else {
+                $note.summernote('pasteHTML', cleanedContent);
+              }
+
               if ($editor.find('.note-status-output').length > 0) {
                 $editor.find('.note-status-output').html(lang.cleaner.not);
                 /*now set a timeout to clear out the message */


### PR DESCRIPTION
Resolved an issue where text was being inserted into the code view was the orignal text while the html inserted into the editor was the cleaned html. 

Running the function before sending the data fixes the issue #103 

Also updated the documentation to be more inline with the current state.