### PR TITLE
Resolved plain text rendering as HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ Replace pasted images with a nominated placeholder.
   - Check out our other Summernote Plugins via our main Github page.
 
 # CHANGELOG:
+#### v1.0.8
+- Resolved issue where text like `<asdf>` was accidentally counted as html when pasting from plain text context
+
 #### v1.0.7
 - Resolved issue in some cases where code view would be out of synch with editor
 

--- a/summernote-cleaner.js
+++ b/summernote-cleaner.js
@@ -1,5 +1,5 @@
 /* https://github.com/DiemenDesign/summernote-cleaner */
-/* Version: 1.0.7 */
+/* Version: 1.0.8 */
 (function(factory) {
   if (typeof define === 'function' && define.amd) {
     define(['jquery'], factory);
@@ -178,8 +178,10 @@
 
       var cleanTextPaste = function(input) {
         var newLines = /(\r\n|\r|\n)/g;
-        var parsedInput = input.split(newLines);
-        if(parsedInput.length === 1) { return input; }
+        /*lets only replace < and > as these are the culprit for HTML tag recognition */
+        let inputEscapedHtml = input.replace('<', '&#60').replace('>', '&#62');
+        var parsedInput = inputEscapedHtml.split(newLines);
+        if(parsedInput.length === 1) { return inputEscapedHtml; }
         var output = "";
         /*for larger blocks of text (such as multiple paragraphs) match summernote markup */
         for (let contentIndex = 0; contentIndex < parsedInput.length; contentIndex++) {


### PR DESCRIPTION
Added escaping for plaintext so `<` and `>` are not recognised as HTML as in isssue #107 
And updated documentation.