### PR TITLE
Fix missing return statements in cleanHtmlPaste

### DIFF
--- a/summernote-cleaner-skunkworks.js
+++ b/summernote-cleaner-skunkworks.js
@@ -209,9 +209,9 @@
 
       var cleanHtmlPaste = function(input, badTags, keepTagContents, badAttributes, keepImages, imagePlaceholder) {
         if (typeof(window.jQuery) === 'function') {
-          cleanHtmlPasteWithjQuery(input, badTags, keepTagContents, badAttributes, keepImages, imagePlaceholder)
+          return cleanHtmlPasteWithjQuery(input, badTags, keepTagContents, badAttributes, keepImages, imagePlaceholder)
         } else {
-          cleanHtmlPasteWithRegExp(input, badTags, keepTagContents, badAttributes, keepImages, imagePlaceholder)
+          return cleanHtmlPasteWithRegExp(input, badTags, keepTagContents, badAttributes, keepImages, imagePlaceholder)
         }
       }
 

--- a/summernote-cleaner.js
+++ b/summernote-cleaner.js
@@ -207,9 +207,9 @@
 
       var cleanHtmlPaste = function(input, badTags, keepTagContents, badAttributes, keepImages, imagePlaceholder) {
         if (typeof(window.jQuery) === 'function') {
-          cleanHtmlPasteWithjQuery(input, badTags, keepTagContents, badAttributes, keepImages, imagePlaceholder)
+          return cleanHtmlPasteWithjQuery(input, badTags, keepTagContents, badAttributes, keepImages, imagePlaceholder)
         } else {
-          cleanHtmlPasteWithRegExp(input, badTags, keepTagContents, badAttributes, keepImages, imagePlaceholder)
+          return cleanHtmlPasteWithRegExp(input, badTags, keepTagContents, badAttributes, keepImages, imagePlaceholder)
         }
       }
 


### PR DESCRIPTION
Functions called in cleanHtmlPaste were missing return statements, resulting in undefined being returned to the paste action. Closes #114 