### PR TITLE
Remove span wrapping in JQuery keepTagContents

### DIFF
--- a/summernote-cleaner-skunkworks.js
+++ b/summernote-cleaner-skunkworks.js
@@ -281,7 +281,7 @@
 
         for (i = 0; i < keepTagContents.length; i++) {
           sanidom.find(keepTagContents[i]).replaceWith(function() {
-            return $('<span/>', { html: $(this).html() });
+            return $(this).html();
           });
         }
 

--- a/summernote-cleaner-skunkworks.js
+++ b/summernote-cleaner-skunkworks.js
@@ -72,22 +72,7 @@
       }
       this.events = {
         'summernote.init': function () {
-          if (options.cleaner.limitChars !== 0 || options.cleaner.limitDisplay !== 'none'){
-            var textLength = $editor.find(".note-editable").text().replace(/(<([^>]+)>)/ig, "").replace(/( )/," ");
-            var codeLength = $editor.find('.note-editable').html();
-            var lengthStatus = '';
-            if (textLength.length > options.cleaner.limitChars&&options.cleaner.limitChars > 0)
-              lengthStatus += 'note-text-danger">';
-            else
-              lengthStatus += '">';
-            if (options.cleaner.limitDisplay === 'text' || options.cleaner.limitDisplay === 'both')
-              lengthStatus += lang.cleaner.limitText + ': ' + textLength.length;
-            if (options.cleaner.limitDisplay === 'both')
-              lengthStatus += ' / ';
-            if (options.cleaner.limitDisplay === 'html' || options.cleaner.limitDisplay === 'both')
-              lengthStatus += lang.cleaner.limitHTML + ': ' + codeLength.length;
-            $editor.find('.note-statusbar').html('<small class="note-pull-right ' + lengthStatus + '&nbsp;</small>');
-          }
+          buildLengthStatusDisplay();
         },
         'summernote.keydown': function (we, event) {
           if (options.cleaner.limitChars !== 0 || options.cleaner.limitDisplay !== 'none') {
@@ -173,6 +158,7 @@
                     $editor.find('.note-statusbar').fadeOut(function(){
                       $(this).html("");
                       $(this).fadeIn();
+                      buildLengthStatusDisplay();
                     });
                   }
                 }, options.cleaner.notTimeOut)
@@ -181,6 +167,26 @@
           }
         }
       }
+
+      var buildLengthStatusDisplay = function() {
+    		if (options.cleaner.limitChars !== 0 || options.cleaner.limitDisplay !== 'none'){
+    			var textLength = $editor.find(".note-editable").text().replace(/(<([^>]+)>)/ig, "").replace(/( )/," ");
+    			var codeLength = $editor.find('.note-editable').html();
+    			var lengthStatus = '';
+    			if (textLength.length > options.cleaner.limitChars&&options.cleaner.limitChars > 0)
+    				lengthStatus += 'note-text-danger">';
+    			else
+    				lengthStatus += '">';
+    			if (options.cleaner.limitDisplay === 'text' || options.cleaner.limitDisplay === 'both')
+    				lengthStatus += lang.cleaner.limitText + ': ' + textLength.length;
+    			if (options.cleaner.limitDisplay === 'both')
+    				lengthStatus += ' / ';
+    			if (options.cleaner.limitDisplay === 'html' || options.cleaner.limitDisplay === 'both')
+    				lengthStatus += lang.cleaner.limitHTML + ': ' + codeLength.length;
+    			$editor.find('.note-status-output').html('<small class="note-pull-right ' + lengthStatus + '&nbsp;</small>');
+    		}
+	    }
+      
       var cleanPaste = function(input, badTags, keepTagContents, badAttributes, keepImages, imagePlaceholder, isHtmlData) {
         if(isHtmlData) {
           return cleanHtmlPaste(input, badTags, keepTagContents, badAttributes, keepImages, imagePlaceholder);

--- a/summernote-cleaner-skunkworks.js
+++ b/summernote-cleaner-skunkworks.js
@@ -279,6 +279,8 @@
           sanidom.find(badTags[i]).remove();
         }
 
+        sanidom.find(':empty').remove();
+
         for (i = 0; i < keepTagContents.length; i++) {
           sanidom.find(keepTagContents[i]).replaceWith(function() {
             return $(this).html();

--- a/summernote-cleaner.js
+++ b/summernote-cleaner.js
@@ -72,22 +72,7 @@
       }
       this.events = {
         'summernote.init': function () {
-          if (options.cleaner.limitChars !== 0 || options.cleaner.limitDisplay !== 'none'){
-            var textLength = $editor.find(".note-editable").text().replace(/(<([^>]+)>)/ig, "").replace(/( )/," ");
-            var codeLength = $editor.find('.note-editable').html();
-            var lengthStatus = '';
-            if (textLength.length > options.cleaner.limitChars&&options.cleaner.limitChars > 0)
-              lengthStatus += 'note-text-danger">';
-            else
-              lengthStatus += '">';
-            if (options.cleaner.limitDisplay === 'text' || options.cleaner.limitDisplay === 'both')
-              lengthStatus += lang.cleaner.limitText + ': ' + textLength.length;
-            if (options.cleaner.limitDisplay === 'both')
-              lengthStatus += ' / ';
-            if (options.cleaner.limitDisplay === 'html' || options.cleaner.limitDisplay === 'both')
-              lengthStatus += lang.cleaner.limitHTML + ': ' + codeLength.length;
-            $editor.find('.note-status-output').html('<small class="note-pull-right ' + lengthStatus + '&nbsp;</small>');
-          }
+          buildLengthStatusDisplay();
         },
         'summernote.keydown': function (we, event) {
           if (options.cleaner.limitChars !== 0 || options.cleaner.limitDisplay !== 'none') {
@@ -171,6 +156,7 @@
                     $editor.find('.note-status-output').fadeOut(function(){
                       $(this).html("");
                       $(this).fadeIn();
+                      buildLengthStatusDisplay();
                     });
                   }
                 }, options.cleaner.notTimeOut)
@@ -179,6 +165,26 @@
           }
         }
       }
+
+      var buildLengthStatusDisplay = function() {
+    		if (options.cleaner.limitChars !== 0 || options.cleaner.limitDisplay !== 'none'){
+    			var textLength = $editor.find(".note-editable").text().replace(/(<([^>]+)>)/ig, "").replace(/( )/," ");
+    			var codeLength = $editor.find('.note-editable').html();
+    			var lengthStatus = '';
+    			if (textLength.length > options.cleaner.limitChars&&options.cleaner.limitChars > 0)
+    				lengthStatus += 'note-text-danger">';
+    			else
+    				lengthStatus += '">';
+    			if (options.cleaner.limitDisplay === 'text' || options.cleaner.limitDisplay === 'both')
+    				lengthStatus += lang.cleaner.limitText + ': ' + textLength.length;
+    			if (options.cleaner.limitDisplay === 'both')
+    				lengthStatus += ' / ';
+    			if (options.cleaner.limitDisplay === 'html' || options.cleaner.limitDisplay === 'both')
+    				lengthStatus += lang.cleaner.limitHTML + ': ' + codeLength.length;
+    			$editor.find('.note-status-output').html('<small class="note-pull-right ' + lengthStatus + '&nbsp;</small>');
+    		}
+	    }
+
       var cleanPaste = function(input, badTags, keepTagContents, badAttributes, keepImages, imagePlaceholder, isHtmlData) {
         if(isHtmlData) {
           return cleanHtmlPaste(input, badTags, keepTagContents, badAttributes, keepImages, imagePlaceholder);

--- a/summernote-cleaner.js
+++ b/summernote-cleaner.js
@@ -277,6 +277,8 @@
           sanidom.find(badTags[i]).remove()
         }
 
+        sanidom.find(':empty').remove();
+
         for (i = 0; i < keepTagContents.length; i++) {
           sanidom.find(keepTagContents[i]).replaceWith(function() {
             return $(this).html();

--- a/summernote-cleaner.js
+++ b/summernote-cleaner.js
@@ -279,7 +279,7 @@
 
         for (i = 0; i < keepTagContents.length; i++) {
           sanidom.find(keepTagContents[i]).replaceWith(function() {
-            return $('<span/>', { html: $(this).html() })
+            return $(this).html();
           });
         }
 


### PR DESCRIPTION
JQuery function was wrapping the contents back in a span element when processing keepTagContents which meant you couldn't remove span elements.